### PR TITLE
Make composer work when open_basedir is set.

### DIFF
--- a/composer
+++ b/composer
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/env php -d allow_url_fopen=On -d detect_unicode=Off -d apc.enable_cli=0 /usr/lib/composer/composer.phar $*
+/usr/bin/env php -d open_basedir= -d allow_url_fopen=On -d detect_unicode=Off -d apc.enable_cli=0 /usr/lib/composer/composer.phar $*


### PR DESCRIPTION
Disable `open_basedir` in the wrapper script.
