### PR TITLE
Add support for HHVM

### DIFF
--- a/composer
+++ b/composer
@@ -1,3 +1,10 @@
 #!/bin/sh
 
-/usr/bin/env php -d open_basedir= -d allow_url_fopen=On -d detect_unicode=Off -d apc.enable_cli=0 /usr/lib/composer/composer.phar $*
+if command -v hhvm > /dev/null; then
+    hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 /usr/lib/composer/composer.phar $*
+elif command -v php > /dev/null; then
+    php -d open_basedir= -d allow_url_fopen=On -d detect_unicode=Off -d apc.enable_cli=0 /usr/lib/composer/composer.phar $*
+else
+    echo "composer requires PHP/HHVM to run"
+    exit 1
+fi

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 7), po-debconf, php5-dev
 Standards-Version: 3.9.4
 
 Package: php5-composer
-Depends: php5-cli
+Depends: php5-cli | hhvm
 Architecture: any
 Description: Dependency Manager for PHP
  Composer is a dependency manager tracking local dependencies of your


### PR DESCRIPTION
- Allow a dependency on `hhvm` instead of php5-cli
- Alter the wrapper script to use HHVM if no command line PHP is found.
